### PR TITLE
Walendo update sync script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,14 +138,16 @@ ${modules_nuke}:
 
 sync: distillery-sync ${modules_sync} 
 
-distillery-sync: distillery-update ${DISTILLERY_ROOT_DIR}/tools/syncWithMaster
-	@${DISTILLERY_ROOT_DIR}/tools/syncWithMaster
+# This is the script we use to sync each repo's origin/master with parc_upstream/master.
+SYNC_TO_UPSTREAM_SCRIPT=syncOriginMasterWithPARCUpstream
+
+distillery-sync: distillery-update ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
+	@${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
 	
-${modules_sync}: ${DISTILLERY_ROOT_DIR}/tools/syncWithMaster
+${modules_sync}: ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAK_SCRIPT}
 	@echo Updating $(@:.sync=)
 	@cd $(@:.sync=); git fetch --all
-	@cd $(@:.sync=); ${DISTILLERY_ROOT_DIR}/tools/syncWithMaster
-
+	@cd $(@:.sync=); ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
 
 clobber: distclean
 	@rm -rf ${CONFIGURE_CACHE_FILE}

--- a/Makefile
+++ b/Makefile
@@ -139,15 +139,15 @@ ${modules_nuke}:
 sync: distillery-sync ${modules_sync} 
 
 # This is the script we use to sync each repo's origin/master with parc_upstream/master.
-SYNC_TO_UPSTREAM_SCRIPT=syncOriginMasterWithPARCUpstream
+SYNC_TO_UPSTREAM_SCRIPT=${DISTILLERY_ROOT_DIR}/tools/syncOriginMasterWithPARCUpstream
 
-distillery-sync: distillery-update ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
-	@${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
+distillery-sync: distillery-update ${SYNC_TO_UPSTREAM_SCRIPT}
+	@${SYNC_TO_UPSTREAM_SCRIPT}
 	
-${modules_sync}: ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAK_SCRIPT}
+${modules_sync}: ${SYNC_TO_UPSTREAK_SCRIPT}
 	@echo Updating $(@:.sync=)
 	@cd $(@:.sync=); git fetch --all
-	@cd $(@:.sync=); ${DISTILLERY_ROOT_DIR}/tools/${SYNC_TO_UPSTREAM_SCRIPT}
+	@cd $(@:.sync=); {SYNC_TO_UPSTREAM_SCRIPT}
 
 clobber: distclean
 	@rm -rf ${CONFIGURE_CACHE_FILE}

--- a/tools/syncOriginMasterWithPARCUpstream.sh
+++ b/tools/syncOriginMasterWithPARCUpstream.sh
@@ -35,15 +35,32 @@
 # If you were on a different branch than master, you should still be on
 # that branch when the script exits.
 
-git remote show parc_upstream > /dev/null
+CWD=`pwd`
+
+echo "Syncing $CWD origin/master with parc_upstream/master"
+
+# First, check if there is a parc_upstream remote at all
+git remote | grep parc_upstream > /dev/null
 if [ $? -ne 0 ]; then
-    exit $?
+    echo "  - No parc_upstream remote found in $CWD - skipping sync"
+    exit 0
+fi
+
+# Now check that origin does not point to a PARC repo
+git remote show origin | grep 'github.com/PARC/'
+if [ $? -eq 0 ]; then
+    echo "  - Origin points to a PARC repo - skipping sync to avoid accidental pushes."
+    exit 0
 fi
 
 BRANCH=`git symbolic-ref --short HEAD`
-echo "Currently on " $BRANCH
 git checkout master && git merge parc_upstream/master && git push
 STATUS=$?
+if [ $? -eq 0 ]; then
+    echo "  - master succesfully synced with parc_upstream/master"
+fi
+
+echo "  - Switching back to branch <$BRANCH> in $CWD"
 git checkout $BRANCH
 
 exit $STATUS

--- a/tools/syncOriginMasterWithPARCUpstream.sh
+++ b/tools/syncOriginMasterWithPARCUpstream.sh
@@ -47,7 +47,7 @@ if [ $? -ne 0 ]; then
 fi
 
 # Now check that origin does not point to a PARC repo
-git remote show origin | grep 'github.com/PARC/'
+git remote show origin | grep 'github.com/PARC/' > /dev/null
 if [ $? -eq 0 ]; then
     echo "  - Origin points to a PARC repo - skipping sync to avoid accidental pushes."
     exit 0


### PR DESCRIPTION
Updated Makefile to put the full path to the sync script in the SYNC_TO_UPSTREAM_SCRIPT variable.
Updated the script to be less verbose in general, but louder when it can't do the sync because of unstaged changes.